### PR TITLE
운행일지 상세 조회시 경로 좌표 정보 전달

### DIFF
--- a/consumer/src/main/java/com/pickcar/application/EventInfoService.java
+++ b/consumer/src/main/java/com/pickcar/application/EventInfoService.java
@@ -53,7 +53,6 @@ public class EventInfoService {
 
     public void writeDriveHistoryRequestAfterOff(EventInfo offEventInfo) {
         RestTemplate restTemplate = restTemplateConfig.restTemplate();
-        log.info("deployDomain: {}", deployDomain);
         restTemplate.postForEntity(deployDomain + "/api/v1/history/%d".formatted(offEventInfo.getId()),
                 null, Void.class);
     }

--- a/consumer/src/main/java/com/pickcar/application/EventInfoService.java
+++ b/consumer/src/main/java/com/pickcar/application/EventInfoService.java
@@ -17,7 +17,7 @@ public class EventInfoService {
 
     private final RestTemplateConfig restTemplateConfig;
 
-    @Value("${custom.deploy.cycle}")
+    @Value("${custom.deploy.domain}")
     private String deployDomain;
 
     private final EventInfoRepository eventInfoRepository;
@@ -53,6 +53,7 @@ public class EventInfoService {
 
     public void writeDriveHistoryRequestAfterOff(EventInfo offEventInfo) {
         RestTemplate restTemplate = restTemplateConfig.restTemplate();
+        log.info("deployDomain: {}", deployDomain);
         restTemplate.postForEntity(deployDomain + "/api/v1/history/%d".formatted(offEventInfo.getId()),
                 null, Void.class);
     }

--- a/database/src/main/java/com/pickcar/drivehistory/domain/DriveHistory.java
+++ b/database/src/main/java/com/pickcar/drivehistory/domain/DriveHistory.java
@@ -37,7 +37,7 @@ public class DriveHistory extends BaseEntity {
         this.reservationId = reservationId;
         this.drivingStartedAt = offEventInfo.getEngineOnTime();
         this.drivingEndedAt = offEventInfo.getEngineOffTime();
-        this.totalDistance = totalDistance;
+        this.totalDistance = totalDistance != null ? totalDistance / 1000 : 0.0;        //FIXME: 임시 위치
         this.totalDrivingTime = calcTotalDrivingTime(offEventInfo.getEngineOnTime(), offEventInfo.getEngineOffTime());
     }
 

--- a/domain/src/main/java/com/pickcar/drivehistory/application/DriveHistoryService.java
+++ b/domain/src/main/java/com/pickcar/drivehistory/application/DriveHistoryService.java
@@ -10,6 +10,7 @@ import com.pickcar.drivehistory.presentation.dto.response.DriveHistoryListRespon
 import com.pickcar.emulator.application.CycleQueryService;
 import com.pickcar.emulator.application.EventInfoQueryService;
 import com.pickcar.emulator.domain.EventInfo;
+import com.pickcar.emulator.presentation.context.PathContext;
 import com.pickcar.reservation.application.ReservationService;
 import com.pickcar.reservation.domain.Reservation;
 import com.pickcar.reservation.presentation.dto.context.ReservationContext;
@@ -108,10 +109,10 @@ public class DriveHistoryService {
 
     public DriveHistoryDetailResponse getDetailResponseById(Long historyId) {
         DriveHistory history = getById(historyId);
-        ReservationContext context = reservationService.getReservationContextById(history.getReservationId());
+        ReservationContext reservationContext = reservationService.getReservationContextById(history.getReservationId());
         //FIXME: path를 가져올 수 있는 다른 방법 필요
-        //Cycle cycle = cycleQueryService.getByVehicleId(context.reservedVehicleInfo().getId());
+        List<PathContext> pathContexts = cycleQueryService.getPathsByReservationAndHistory(reservationContext.reservation(), history);
 
-        return DriveHistoryDetailResponse.of(history, context);
+        return DriveHistoryDetailResponse.of(history, reservationContext, pathContexts);
     }
 }

--- a/domain/src/main/java/com/pickcar/drivehistory/presentation/dto/response/DriveHistoryDetailResponse.java
+++ b/domain/src/main/java/com/pickcar/drivehistory/presentation/dto/response/DriveHistoryDetailResponse.java
@@ -2,10 +2,12 @@ package com.pickcar.drivehistory.presentation.dto.response;
 
 import com.pickcar.drivehistory.domain.DriveHistory;
 import com.pickcar.dto.CycleInfoPayload;
+import com.pickcar.emulator.presentation.context.PathContext;
 import com.pickcar.reservation.domain.ReservationStatus;
 import com.pickcar.reservation.presentation.dto.context.ReservationContext;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -17,14 +19,15 @@ public record DriveHistoryDetailResponse(
         LocalDateTime drivingStartedAt,
         LocalTime totalDrivingTime,
         Double totalDistance,
-        String driverName
+        String driverName,
+        List<PathContext> paths
 //        Double speedAvg
 //        Double lastLongitude,
 //        Double lastLatitude
-//        List<CycleInfoPayload> path
+
 ) {
 
-    public static DriveHistoryDetailResponse of(DriveHistory history, ReservationContext context) {
+    public static DriveHistoryDetailResponse of(DriveHistory history, ReservationContext context, List<PathContext> paths) {
         return DriveHistoryDetailResponse.builder()
                 .licensePlate(context.reservedVehicleInfo().getLicensePlate())
                 .model(context.reservedVehicleInfo().getModel())
@@ -34,6 +37,7 @@ public record DriveHistoryDetailResponse(
                 .totalDrivingTime(history.getTotalDrivingTime())
                 .totalDistance(history.getTotalDistance())
                 .driverName(context.reservedUserInfo().getName())
+                .paths(paths)
                 .build();
     }
 }

--- a/domain/src/main/java/com/pickcar/emulator/application/CycleQueryService.java
+++ b/domain/src/main/java/com/pickcar/emulator/application/CycleQueryService.java
@@ -1,8 +1,13 @@
 package com.pickcar.emulator.application;
 
+import com.pickcar.drivehistory.domain.DriveHistory;
 import com.pickcar.emulator.domain.Cycle;
 import com.pickcar.emulator.domain.EventInfo;
 import com.pickcar.emulator.infrastructure.CycleQueryRepository;
+import com.pickcar.emulator.presentation.context.PathContext;
+import com.pickcar.reservation.domain.Reservation;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -31,8 +36,23 @@ public class CycleQueryService {
                 offEventInfo.getEngineOnTime(), offEventInfo.getEngineOffTime());
     }
 
-    public Cycle getByVehicleId(Long vehicleId) {
-        return cycleQueryRepository.findByVehicleId(vehicleId)
-                .orElseThrow(() -> new IllegalArgumentException("cycle not found for vehicleId: " + vehicleId));
+    public List<PathContext> getPathsByReservationAndHistory(Reservation reservation, DriveHistory driveHistory) {
+        LocalDateTime startedAt = driveHistory.getDrivingStartedAt();
+        LocalDateTime endedAt = driveHistory.getDrivingEndedAt();
+        Long vehicleId = reservation.getVehicleId();
+
+        List<Cycle> cycles = cycleQueryRepository.findAllByVehicleIdAndOccurredAtBetween(vehicleId, startedAt, endedAt);
+        List<PathContext> paths = new ArrayList<>();
+
+        cycles.stream()
+                .forEach((cycle) -> {
+                    cycle.getCycleInfos().stream()
+                                    .forEach((cycleInfo) -> {
+                                        PathContext path = PathContext.of(cycleInfo);
+                                        paths.add(path);
+                                    });
+                });
+
+        return paths;
     }
 }

--- a/domain/src/main/java/com/pickcar/emulator/presentation/context/PathContext.java
+++ b/domain/src/main/java/com/pickcar/emulator/presentation/context/PathContext.java
@@ -1,0 +1,12 @@
+package com.pickcar.emulator.presentation.context;
+
+import com.pickcar.dto.CycleInfoPayload;
+public record PathContext(
+        Double longitude,
+        Double latitude
+) {
+
+    public static PathContext of(CycleInfoPayload cycleInfo) {
+        return new PathContext(cycleInfo.getLongitude(), cycleInfo.getLatitude());
+    }
+}


### PR DESCRIPTION
## 개요

운행일지 상세 조회시 경로 좌표 정보 전달

## 기능 목록
- [x] 운행일지 상세 정보 요청시 운행에 맞는 사이클 내용이 전부 경로로 찍힘
- [x] 운행일지 주행 거리 기본 단위를 km로 임시 변경

## 작업 상세 내용

- 운행일지 상세 조회시 실제 연관된 history, reservation 기반으로 경로 좌표 정보를 전달합니다

- Cycle은 distance가 미터 단위이었지만, DrivingHistory는 km가 될 수 있도록 임시 변경 하였습니다

## 스크린샷(Optional)
(예시는 한 사이클 - 60개지만 5번 주기 찍으면 300개로 나온 것 확인 했습니다)
![image](https://github.com/user-attachments/assets/9861a7f5-02e1-46c1-9d29-551286c4d4f8)

## 기타 공유 사항
JPA로 조회한거라 조회 성능이 많이 떨어져서 추후 개선이 필요합니다
카카오 모빌리티 API로 판교_울산, 판교_수원, 용인_판교 이런 좌표값 받아왔습니다


## 연결 이슈(닫을 이슈)
closes #94
